### PR TITLE
Fix negative temperatures and stash raw packet

### DIFF
--- a/TempSensorDecode.h
+++ b/TempSensorDecode.h
@@ -23,6 +23,7 @@ class TempSensorDecode
     static bool getIsButtonPressed();
     static uint8_t getBatteryState();
     static uint8_t getChannel();
+    static uint64_t getRawPacket();
 
   private:
   	TempSensorDecode() {}
@@ -34,6 +35,7 @@ class TempSensorDecode
     static volatile uint8_t _channel;
     static volatile bool _hasNewData;
     static volatile bool _hasAnyData;
+    static volatile uint64_t _packet_raw;
 
     static void _handleInterrupt();
     static void _handleDuration(unsigned long duration);


### PR DESCRIPTION
This fixes decoding negative (celsius) temperatures so that we can
properly expose below-freezing temperatures. In order to get those,
we need to do an arithmetic right shift with the high-order nibble
in the high byte.

This also stashes the raw packet for later retrieval to make debugging
issues like this easier.
